### PR TITLE
Supporting KamajiControlPlane conditions

### DIFF
--- a/api/v1alpha1/kamajicontrolplane_conditions.go
+++ b/api/v1alpha1/kamajicontrolplane_conditions.go
@@ -1,0 +1,15 @@
+// Copyright 2023 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+type KamajiControlPlaneConditionType string
+
+var (
+	TenantControlPlaneCreatedConditionType      KamajiControlPlaneConditionType = "TenantControlPlaneCreated"
+	TenantControlPlaneAddressReadyConditionType KamajiControlPlaneConditionType = "TenantcontrolPlaneAddressReady"
+	InfrastructureClusterPatchedConditionType   KamajiControlPlaneConditionType = "InfrastructureClusterPatched"
+	KamajiControlPlaneInitializedConditionType  KamajiControlPlaneConditionType = "KamajiControlPlaneIsInitialized"
+	KamajiControlPlaneReadyConditionType        KamajiControlPlaneConditionType = "KamajiControlPlaneIsReady"
+	KubeadmResourcesCreatedReadyConditionType   KamajiControlPlaneConditionType = "KubeadmResourcesCreated"
+)

--- a/api/v1alpha1/kamajicontrolplane_types.go
+++ b/api/v1alpha1/kamajicontrolplane_types.go
@@ -135,7 +135,8 @@ type KamajiControlPlaneStatus struct {
 	// The error message, if available, for the failing reconciliation.
 	FailureMessage string `json:"failureMessage,omitempty"`
 	// String representing the minimum Kubernetes version for the control plane machines in the cluster.
-	Version string `json:"version"`
+	Version    string             `json:"version"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -11,6 +11,7 @@ package v1alpha1
 import (
 	apiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -233,6 +234,13 @@ func (in *KamajiControlPlaneStatus) DeepCopyInto(out *KamajiControlPlaneStatus) 
 		in, out := &in.ExternalManagedControlPlane, &out.ExternalManagedControlPlane
 		*out = new(bool)
 		**out = **in
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]metav1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -3758,6 +3758,49 @@ spec:
           status:
             description: KamajiControlPlaneStatus defines the observed state of KamajiControlPlane.
             properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               externalManagedControlPlane:
                 default: true
                 description: ExternalManagedControlPlane indicates to Cluster API that the Control Plane is externally managed by Kamaji.

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -6097,6 +6097,74 @@ spec:
           status:
             description: KamajiControlPlaneStatus defines the observed state of KamajiControlPlane.
             properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               externalManagedControlPlane:
                 default: true
                 description: ExternalManagedControlPlane indicates to Cluster API

--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/clastix/cluster-api-control-plane-provider-kamaji/api/v1alpha1"
+)
+
+func TrackConditionType(conditions *[]metav1.Condition, conditionType v1alpha1.KamajiControlPlaneConditionType, observedGeneration int64, fn func() error) { //nolint:varnamelen
+	condition := meta.FindStatusCondition(*conditions, string(conditionType))
+	if condition == nil {
+		condition = &metav1.Condition{Type: string(conditionType)}
+	}
+
+	condition.ObservedGeneration = observedGeneration
+
+	defer func() {
+		meta.SetStatusCondition(conditions, *condition)
+	}()
+
+	if err := fn(); err != nil {
+		if condition.Status != metav1.ConditionFalse {
+			condition.LastTransitionTime = metav1.Now()
+		}
+
+		condition.Reason = "Failed"
+		condition.Status = metav1.ConditionFalse
+		condition.Message = err.Error()
+	} else {
+		if condition.Status != metav1.ConditionTrue {
+			condition.LastTransitionTime = metav1.Now()
+		}
+
+		condition.Reason = "Succeeded"
+		condition.Status = metav1.ConditionTrue
+		condition.Message = ""
+	}
+}


### PR DESCRIPTION
Closes #52.

This will remove any chance of getting stuck with unrecoverable clusters due to the error status handling.

Rather, a set of conditions will be reported as it follows:

```yaml
status:
  conditions:
  - lastTransitionTime: "2023-09-22T08:24:25Z"
    message: ""
    reason: Completed
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-09-22T08:24:54Z"
    message: ""
    reason: Completed
    status: "True"
    type: TenantcontrolPlaneAddressReady
  - lastTransitionTime: "2023-09-22T08:25:40Z"
    message: ""
    reason: Completed
    status: "True"
    type: InfrastructureClusterPatched
  - lastTransitionTime: "2023-09-22T08:25:47Z"
    message: ""
    reason: Completed
    status: "True"
    type: KamajiControlPlaneIsInitialized
  - lastTransitionTime: "2023-09-22T08:25:51Z"
    message: ""
    reason: Completed
    status: "True"
    type: KamajiControlPlaneIsReady
  - lastTransitionTime: "2023-09-22T08:26:00Z"
    message: ""
    reason: Completed
    status: "True"
    type: KubeadmResourcesCreated
```
@fchiacchiaretta  @sn4psh0t may I ask you to test this widely, please? I already mocked some errors, however real testing in a real environment would be much worth.