### PR TITLE
Refactoring KamajiControlPlane Ready status report

### DIFF
--- a/api/v1alpha1/kamajicontrolplane_conditions.go
+++ b/api/v1alpha1/kamajicontrolplane_conditions.go
@@ -7,7 +7,7 @@ type KamajiControlPlaneConditionType string
 
 var (
 	TenantControlPlaneCreatedConditionType      KamajiControlPlaneConditionType = "TenantControlPlaneCreated"
-	TenantControlPlaneAddressReadyConditionType KamajiControlPlaneConditionType = "TenantcontrolPlaneAddressReady"
+	TenantControlPlaneAddressReadyConditionType KamajiControlPlaneConditionType = "TenantControlPlaneAddressReady"
 	InfrastructureClusterPatchedConditionType   KamajiControlPlaneConditionType = "InfrastructureClusterPatched"
 	KamajiControlPlaneInitializedConditionType  KamajiControlPlaneConditionType = "KamajiControlPlaneIsInitialized"
 	KamajiControlPlaneReadyConditionType        KamajiControlPlaneConditionType = "KamajiControlPlaneIsReady"

--- a/api/v1alpha1/kamajicontrolplane_types.go
+++ b/api/v1alpha1/kamajicontrolplane_types.go
@@ -125,9 +125,9 @@ type DeploymentComponent struct {
 
 // KamajiControlPlaneStatus defines the observed state of KamajiControlPlane.
 type KamajiControlPlaneStatus struct {
-	// the TenantControlPlane has completed initialization.
+	// The TenantControlPlane has completed initialization.
 	Initialized bool `json:"initialized"`
-	// The TenantControlPlane API Server is ready to receive requests.
+	// The Kamaji Control Plane is ready to link Cluster API with the Tenant Control Plane.
 	Ready bool `json:"ready"`
 
 	// Total number of fully running and ready control plane instances.

--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -3819,10 +3819,10 @@ spec:
                 description: Share the failed process of the KamajiControlPlane provider which wasn't able to complete the reconciliation for the given resource.
                 type: string
               initialized:
-                description: the TenantControlPlane has completed initialization.
+                description: The TenantControlPlane has completed initialization.
                 type: boolean
               ready:
-                description: The TenantControlPlane API Server is ready to receive requests.
+                description: The Kamaji Control Plane is ready to link Cluster API with the Tenant Control Plane.
                 type: boolean
               readyReplicas:
                 description: Total number of fully running and ready control plane instances.

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -6185,11 +6185,11 @@ spec:
                   which wasn't able to complete the reconciliation for the given resource.
                 type: string
               initialized:
-                description: the TenantControlPlane has completed initialization.
+                description: The TenantControlPlane has completed initialization.
                 type: boolean
               ready:
-                description: The TenantControlPlane API Server is ready to receive
-                  requests.
+                description: The Kamaji Control Plane is ready to link Cluster API
+                  with the Tenant Control Plane.
                 type: boolean
               readyReplicas:
                 description: Total number of fully running and ready control plane

--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -4,6 +4,7 @@
 package controllers
 
 import (
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -27,16 +28,23 @@ func TrackConditionType(conditions *[]metav1.Condition, conditionType v1alpha1.K
 			condition.LastTransitionTime = metav1.Now()
 		}
 
-		condition.Reason = "Failed"
-		condition.Status = metav1.ConditionFalse
-		condition.Message = err.Error()
-	} else {
-		if condition.Status != metav1.ConditionTrue {
-			condition.LastTransitionTime = metav1.Now()
+		if errors.Is(err, ErrEnqueueBack) {
+			condition.Reason = "Failed"
+		} else {
+			condition.Reason = "Pending"
 		}
 
-		condition.Reason = "Succeeded"
-		condition.Status = metav1.ConditionTrue
-		condition.Message = ""
+		condition.Status = metav1.ConditionFalse
+		condition.Message = err.Error()
+
+		return
 	}
+
+	if condition.Status != metav1.ConditionTrue {
+		condition.LastTransitionTime = metav1.Now()
+	}
+
+	condition.Reason = "Succeeded"
+	condition.Status = metav1.ConditionTrue
+	condition.Message = ""
 }


### PR DESCRIPTION
Closes #66.

@jds9090 I tried to summarize the state transitions in the following YAML, let me know what do you think.

```yaml
apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
kind: KamajiControlPlane
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"controlplane.cluster.x-k8s.io/v1alpha1","kind":"KamajiControlPlane","metadata":{"annotations":{},"creationTimestamp":"2023-10-12T10:16:00Z","generation":2,"labels":{"cluster.x-k8s.io/cluster-name":"capi-quickstart"},"name":"capi-quickstart-kubevirt","namespace":"default","ownerReferences":[{"apiVersion":"cluster.x-k8s.io/v1beta1","blockOwnerDeletion":true,"controller":true,"kind":"Cluster","name":"capi-quickstart","uid":"913044ea-5135-4a61-a230-f07132d9ea04"}],"resourceVersion":"4317317","uid":"c8943729-c308-4a55-9630-6e5830a2b57a"},"spec":{"addons":{"coreDNS":{"dnsServiceIPs":["10.96.0.10"]},"kubeProxy":{}},"dataStoreName":"default","kubelet":{"cgroupfs":"systemd","preferredAddressTypes":["InternalIP","ExternalIP"]},"network":{"serviceType":"LoadBalancer"},"registry":"registry.k8s.io","replicas":2,"version":"1.23.10"},"status":{"externalManagedControlPlane":true,"initialized":true,"ready":true,"readyReplicas":2,"replicas":2,"selector":"cluster.x-k8s.io/cluster-name=capi-quickstart","unavailableReplicas":0,"updatedReplicas":2,"version":"v1.23.10"}}
  creationTimestamp: "2023-12-11T16:59:14Z"
  generation: 1
  labels:
    cluster.x-k8s.io/cluster-name: capi-quickstart
  name: capi-quickstart-kubevirt
  namespace: default
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: Cluster
    name: capi-quickstart
    uid: 913044ea-5135-4a61-a230-f07132d9ea04
  resourceVersion: "4334700"
  uid: d1765689-f8c4-42ff-9e50-4b4f59671211
spec:
  addons:
    coreDNS:
      dnsServiceIPs:
      - 10.96.0.10
    kubeProxy: {}
  dataStoreName: default
  kubelet:
    cgroupfs: systemd
    preferredAddressTypes:
    - InternalIP
    - ExternalIP
  network:
    serviceType: LoadBalancer
  registry: registry.k8s.io
  replicas: 2
  version: 1.23.10
---
# REDACTED
status:
  conditions:
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: Control Plane Endpoint is not yet available since unprocessed by Kamaji
    observedGeneration: 1
    reason: Pending
    status: "False"
    type: TenantcontrolPlaneAddressReady
  externalManagedControlPlane: true
  initialized: false
  ready: false
  readyReplicas: 0
  replicas: 0
  selector: ""
  unavailableReplicas: 0
  updatedReplicas: 0
  version: ""
---
# REDACTED
status:
  conditions:
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: Control Plane Endpoint is not yet available since unprocessed by Kamaji
    observedGeneration: 1
    reason: Pending
    status: "False"
    type: TenantcontrolPlaneAddressReady
  externalManagedControlPlane: true
  initialized: true
  ready: false
  readyReplicas: 0
  replicas: 0
  selector: ""
  unavailableReplicas: 0
  updatedReplicas: 0
  version: ""
---
# REDACTED
status:
  conditions:
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: Control Plane Endpoint is not yet available since unprocessed by Kamaji
    observedGeneration: 1
    reason: Pending
    status: "False"
    type: TenantcontrolPlaneAddressReady
  externalManagedControlPlane: true
  initialized: true
  ready: false
  readyReplicas: 0
  replicas: 0
  selector: cluster.x-k8s.io/cluster-name=capi-quickstart
  unavailableReplicas: 0
  updatedReplicas: 0
  version: ""
---
# REDACTED
status:
  conditions:
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantcontrolPlaneAddressReady
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: InfrastructureClusterPatched
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KamajiControlPlaneIsInitialized
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: admin kubeconfig still unprocessed by Kamaji, enqueue back
    observedGeneration: 1
    reason: Failed
    status: "False"
    type: KubeadmResourcesCreated
  externalManagedControlPlane: true
  initialized: true
  ready: false
  readyReplicas: 0
  replicas: 0
  selector: cluster.x-k8s.io/cluster-name=capi-quickstart
  unavailableReplicas: 0
  updatedReplicas: 0
  version: ""
---
# REDACTED
status:
  conditions:
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantcontrolPlaneAddressReady
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: InfrastructureClusterPatched
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KamajiControlPlaneIsInitialized
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KubeadmResourcesCreated
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: TenantControlPlane in Provisioning status, enqueue back
    observedGeneration: 1
    reason: Failed
    status: "False"
    type: KamajiControlPlaneIsReady
  externalManagedControlPlane: true
  initialized: true
  ready: false
  readyReplicas: 0
  replicas: 0
  selector: cluster.x-k8s.io/cluster-name=capi-quickstart
  unavailableReplicas: 0
  updatedReplicas: 0
  version: ""
---
# REDACTED
status:
  conditions:
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantcontrolPlaneAddressReady
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: InfrastructureClusterPatched
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KamajiControlPlaneIsInitialized
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KubeadmResourcesCreated
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: TenantControlPlane in Provisioning status, enqueue back
    observedGeneration: 1
    reason: Failed
    status: "False"
    type: KamajiControlPlaneIsReady
  externalManagedControlPlane: true
  initialized: true
  ready: false
  readyReplicas: 0
  replicas: 0
  selector: cluster.x-k8s.io/cluster-name=capi-quickstart
  unavailableReplicas: 2
  updatedReplicas: 0
  version: ""
---
# REDACTED
status:
  conditions:
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantcontrolPlaneAddressReady
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: InfrastructureClusterPatched
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KamajiControlPlaneIsInitialized
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KubeadmResourcesCreated
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: TenantControlPlane in Provisioning status, enqueue back
    observedGeneration: 1
    reason: Failed
    status: "False"
    type: KamajiControlPlaneIsReady
  externalManagedControlPlane: true
  initialized: true
  ready: false
  readyReplicas: 0
  replicas: 2
  selector: cluster.x-k8s.io/cluster-name=capi-quickstart
  unavailableReplicas: 2
  updatedReplicas: 2
  version: ""
---
# REDACTED
status:
  conditions:
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantcontrolPlaneAddressReady
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: InfrastructureClusterPatched
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KamajiControlPlaneIsInitialized
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KubeadmResourcesCreated
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: TenantControlPlane in Provisioning status, enqueue back
    observedGeneration: 1
    reason: Failed
    status: "False"
    type: KamajiControlPlaneIsReady
  externalManagedControlPlane: true
  initialized: true
  ready: false
  readyReplicas: 2
  replicas: 2
  selector: cluster.x-k8s.io/cluster-name=capi-quickstart
  unavailableReplicas: 0
  updatedReplicas: 2
  version: v1.23.10
---
# REDACTED
status:
  conditions:
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantcontrolPlaneAddressReady
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: InfrastructureClusterPatched
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KamajiControlPlaneIsInitialized
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KubeadmResourcesCreated
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: TenantControlPlane in Provisioning status, enqueue back
    observedGeneration: 1
    reason: Failed
    status: "False"
    type: KamajiControlPlaneIsReady
  externalManagedControlPlane: true
  initialized: true
  ready: true
  readyReplicas: 2
  replicas: 2
  selector: cluster.x-k8s.io/cluster-name=capi-quickstart
  unavailableReplicas: 0
  updatedReplicas: 2
  version: v1.23.10
---
# REDACTED
status:
  conditions:
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantControlPlaneCreated
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: TenantcontrolPlaneAddressReady
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: InfrastructureClusterPatched
  - lastTransitionTime: "2023-12-11T16:59:14Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KamajiControlPlaneIsInitialized
  - lastTransitionTime: "2023-12-11T16:59:16Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KubeadmResourcesCreated
  - lastTransitionTime: "2023-12-11T16:59:28Z"
    message: ""
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: KamajiControlPlaneIsReady
  externalManagedControlPlane: true
  initialized: true
  ready: true
  readyReplicas: 2
  replicas: 2
  selector: cluster.x-k8s.io/cluster-name=capi-quickstart
  unavailableReplicas: 0
  updatedReplicas: 2
  version: v1.23.10
```