### PR TITLE
Allow overriding secretKey for kubeconfig

### DIFF
--- a/controllers/kamajicontrolplane_controller_tcp.go
+++ b/controllers/kamajicontrolplane_controller_tcp.go
@@ -24,6 +24,16 @@ func (r *KamajiControlPlaneReconciler) createOrUpdateTenantControlPlane(ctx cont
 	tcp.Name = kcp.GetName()
 	tcp.Namespace = kcp.GetNamespace()
 
+	if tcp.Annotations == nil {
+		tcp.Annotations = make(map[string]string)
+	}
+
+	if kubeconfigSecretKey := kcp.Annotations[kamajiv1alpha1.KubeconfigSecretKeyAnnotation]; kubeconfigSecretKey != "" {
+		tcp.Annotations[kamajiv1alpha1.KubeconfigSecretKeyAnnotation] = kubeconfigSecretKey
+	} else {
+		delete(tcp.Annotations, kamajiv1alpha1.KubeconfigSecretKeyAnnotation)
+	}
+
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		_, scopeErr := controllerutil.CreateOrUpdate(ctx, r.client, tcp, func() error {
 			// TenantControlPlane port


### PR DESCRIPTION
During reconciliation, the control plane provider copies the content from the secret provided by Kamaji, named <cluster>-admin-kubeconfig, into a generic Cluster API secret, <cluster>-kubeconfig, which can then be used by the bootstrap provider and other cluster components.

This change introduces a new annotation, kamaji.clastix.io/kubeconfig-secret-key, for the KamajiControlPlane resource. This annotation instructs the control plane provider to read the kubeconfig from a specific key (the default one is admin.conf).

Example:

```
kamaji.clastix.io/kubeconfig-secret-key: super-admin.svc
```

This will instruct the system to use `super-admin.svc` a kubeconfig with a local service FQDN (introduced by https://github.com/clastix/kamaji/pull/403).

And also copy this annotation for TenantControlPlane object (see: https://github.com/clastix/kamaji/pull/408)

requires https://github.com/clastix/cluster-api-control-plane-provider-kamaji/pull/93 to get merged first