### PR TITLE
Fix reconcilation problem after restore KamajiControlPlane from backup

### DIFF
--- a/controllers/kamajicontrolplane_controller_resources.go
+++ b/controllers/kamajicontrolplane_controller_resources.go
@@ -74,7 +74,7 @@ func (r *KamajiControlPlaneReconciler) createOrUpdateCertificateAuthority(ctx co
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		_, scopeErr := controllerutil.CreateOrUpdate(ctx, r.client, capiCA, func() error {
 			// Skipping the replication of the Certificate Authority if the Secret is managed by the Kamaji operator
-			if len(capiCA.GetOwnerReferences()) > 0 && capiCA.OwnerReferences[0].Kind == "TenantControlPlane" {
+			if capiCA.Name == kamajiCA.Name {
 				return nil
 			}
 


### PR DESCRIPTION
My goal is  restore managed cluster from backup.
I use Velero for restore.
First of all I recover etcd database, TenantControlPlane and other generic capi resources.
On last stage I have to recover KamajiControlPlane resource.

KamajiControlPlane gets "Ready" status, but I see error in kamaji control plane controller's log:

`2024-02-21T13:54:48Z ERROR Reconciler error {"controller": "kamajicontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "KamajiControlPlane", "KamajiControlPlane": {"name":"ocean-ocean-avkontya3-jvpinos","namespace":"ocean-ocean-avkontya3-jvpinos"}, "namespace": "ocean-ocean-avkontya3-jvpinos", "name": "ocean-ocean-avkontya3-jvpinos", "reconcileID": "2cece214-b52e-41fc-884a-cac3ebd28bd6", "error": "cannot create or update CA secret: missing Certificate value from *kamajiv1alpha1.TenantControlPlane CA", "errorVerbose": "missing Certificate value from *kamajiv1alpha1.TenantControlPlane CA\ngithub.com/clastix/cluster-api-control-plane-provider-kamaji/controllers.(*KamajiControlPlaneReconciler).createOrUpdateCertificateAuthor`


**Wanted behavior:** KamajiControlPlane controller pickes up existing kamajiCA secret.

**Cause of problem:**
In my case kamajiCA and capiCA secret names are equals. Also when I restore kcp with Velero, it doesn't restore secret OwnerReferences. Kamaji control plane detects it like it's own object and delete "ca.crt" and "ca.key" data in kamajiCA secret. On the second iteration it makes error, because ca.crt deleted.

**How I solved the error:** 
Our provider doesn't have to control KamajiCA secret.
I replaced condition that check who is owner of CA secret.
Now we control it by secret names.





