### PR TITLE
fix(tilt): force user in tilt Dockerfile

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -10,7 +10,8 @@
         "config",
         "controllers"
       ],
-      "label": "CACPPK"
+      "label": "CACPPK",
+      "additional_docker_build_commands": "USER 65532:65532"
     }
 }
 


### PR DESCRIPTION
When running CACPPK with cluster-api Tiltfile, I get this following error:

```
[event: pod kamaji-system/capi-kamaji-controller-manager-54976585c9-mqrt9] Error: container has runAsNonRoot and image will run as root (pod: "capi-kamaji-controller-manager-54976585c9-mqrt9_kamaji-system(3b84c5c0-3e3b-453e-9dd2-4418c0bfaaf7)", container: manager)
```

This is because with cluster-api Tiltfile, tilt is generating a Dockerfile and it's not using the one in `cluster-api-control-plane-provider-kamaji`.

This MR fix this issue by adding `USER` directive to the generated Dockerfile