### PR TITLE
fix: patchCluster not working on vsphere

### DIFF
--- a/controllers/kamajicontrolplane_controller_cluster_patch.go
+++ b/controllers/kamajicontrolplane_controller_cluster_patch.go
@@ -60,7 +60,7 @@ func (r *KamajiControlPlaneReconciler) patchCluster(ctx context.Context, cluster
 
 func (r *KamajiControlPlaneReconciler) checkOrPatchVSphereCluster(ctx context.Context, cluster capiv1beta1.Cluster, endpoint string, port int64) error {
 	if err := r.checkGenericCluster(ctx, cluster, endpoint, port); err != nil {
-		if errors.Is(err, UnmanagedControlPlaneAddressError{}) {
+		if errors.As(err, &UnmanagedControlPlaneAddressError{}) {
 			return r.patchGenericCluster(ctx, cluster, endpoint, port, false)
 		}
 
@@ -134,7 +134,7 @@ func (r *KamajiControlPlaneReconciler) checkGenericCluster(ctx context.Context, 
 	cpHost, cpPort := controlPlaneEndpoint["host"].(string), controlPlaneEndpoint["port"].(int64) //nolint:forcetypeassert
 
 	if len(cpHost) == 0 && cpPort == 0 {
-		return NewUnmanagedControlPlaneAddressError(gkc.GetKind())
+		return *NewUnmanagedControlPlaneAddressError(gkc.GetKind())
 	}
 
 	if cpHost != endpoint {

--- a/controllers/kamajicontrolplane_controller_cluster_patch_errors.go
+++ b/controllers/kamajicontrolplane_controller_cluster_patch_errors.go
@@ -16,5 +16,5 @@ func NewUnmanagedControlPlaneAddressError(kind string) *UnmanagedControlPlaneAdd
 }
 
 func (u UnmanagedControlPlaneAddressError) Error() string {
-	return fmt.Sprintf("the %s resource is not managaing directly the Control Plane address", u.Kind)
+	return fmt.Sprintf("the %s resource is not directly managing the Control Plane address", u.Kind)
 }


### PR DESCRIPTION
Patching the controlPlaneEndpoint in the VSphere cluster was broken due to a bad comparison (Is instead of As, so comparing the error contents instead of the error type). This PR fixes that.

I also fixed a typo in the error message itself.