### PR TITLE
fix: go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.22 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Fix regression introduced by https://github.com/clastix/cluster-api-control-plane-provider-kamaji/pull/93

Without this build fails:

```
go fmt ./...
go vet ./...
test -s /Users/kvaps/git/cluster-api-control-plane-provider-kamaji/bin/setup-envtest || GOBIN=/Users/kvaps/git/cluster-api-control-plane-provider-kamaji/bin go install sigs.k8s.io/controller
-runtime/tools/setup-envtest@latest
KUBEBUILDER_ASSETS="/Users/kvaps/git/cluster-api-control-plane-provider-kamaji/bin/k8s/1.25.0-darwin-arm64" go test ./... -coverprofile cover.out
        github.com/clastix/cluster-api-control-plane-provider-kamaji            coverage: 0.0% of statements
        github.com/clastix/cluster-api-control-plane-provider-kamaji/api/v1alpha1               coverage: 0.0% of statements
fork/exec /var/folders/j6/3192bzpj19l704yqhbz8hx000000gn/T/go-build1927485611/b708/controllers.test: exec format error
FAIL    github.com/clastix/cluster-api-control-plane-provider-kamaji/controllers        0.002s
FAIL
make: *** [Makefile:110: test] Error 1
```