### PR TITLE
feat: Add categories and short name to CRD

### DIFF
--- a/api/v1alpha1/kamajicontrolplane_types.go
+++ b/api/v1alpha1/kamajicontrolplane_types.go
@@ -162,6 +162,7 @@ type KamajiControlPlaneStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:categories=cluster-api;kamaji,shortName=kjcp
 //+kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 //+kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.version",description="The desired Kubernetes version"
 //+kubebuilder:printcolumn:name="Initialized",type="boolean",JSONPath=".status.initialized",description="Check if the Kamaji Control Plane has been initialized"

--- a/api/v1alpha1/kamajicontrolplane_types.go
+++ b/api/v1alpha1/kamajicontrolplane_types.go
@@ -162,7 +162,7 @@ type KamajiControlPlaneStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:categories=cluster-api;kamaji,shortName=kjcp
+//+kubebuilder:resource:categories=cluster-api;kamaji,shortName=ktcp
 //+kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 //+kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.version",description="The desired Kubernetes version"
 //+kubebuilder:printcolumn:name="Initialized",type="boolean",JSONPath=".status.initialized",description="Check if the Kamaji Control Plane has been initialized"

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -15,7 +15,7 @@ spec:
     listKind: KamajiControlPlaneList
     plural: kamajicontrolplanes
     shortNames:
-    - kjcp
+    - ktcp
     singular: kamajicontrolplane
   scope: Namespaced
   versions:

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -8,9 +8,14 @@ metadata:
 spec:
   group: controlplane.cluster.x-k8s.io
   names:
+    categories:
+    - cluster-api
+    - kamaji
     kind: KamajiControlPlane
     listKind: KamajiControlPlaneList
     plural: kamajicontrolplanes
+    shortNames:
+    - kjcp
     singular: kamajicontrolplane
   scope: Namespaced
   versions:


### PR DESCRIPTION
Add categories to KamajiControlPlane so that they can be inspected together with other Cluster API resources and TCPs.
```
kubectl get cluster-api
kubectl get kamaji
```

Also add a short name. I chose `kjcp` because `kcp` is already taken. I'm open to change it though