### PR TITLE
Accept version strings with and without a 'v' prefix

### DIFF
--- a/api/v1alpha1/kamajicontrolplane_types.go
+++ b/api/v1alpha1/kamajicontrolplane_types.go
@@ -81,7 +81,6 @@ type KamajiControlPlaneSpec struct {
 	// +kubebuilder:default=2
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Version defines the desired Kubernetes version.
-	// Use the semantic version without the `v` prefix, such as 1.27.0
 	Version string `json:"version"`
 }
 

--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -6500,9 +6500,7 @@ spec:
                     type: object
                 type: object
               version:
-                description: |-
-                  Version defines the desired Kubernetes version.
-                  Use the semantic version without the `v` prefix, such as 1.27.0
+                description: Version defines the desired Kubernetes version.
                 type: string
             required:
             - dataStoreName

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -6785,9 +6785,7 @@ spec:
                     type: object
                 type: object
               version:
-                description: |-
-                  Version defines the desired Kubernetes version.
-                  Use the semantic version without the `v` prefix, such as 1.27.0
+                description: Version defines the desired Kubernetes version.
                 type: string
             required:
             - dataStoreName

--- a/controllers/kamajicontrolplane_controller_tcp.go
+++ b/controllers/kamajicontrolplane_controller_tcp.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -53,7 +54,12 @@ func (r *KamajiControlPlaneReconciler) createOrUpdateTenantControlPlane(ctx cont
 			// Replicas
 			tcp.Spec.ControlPlane.Deployment.Replicas = kcp.Spec.Replicas
 			// Version
-			tcp.Spec.Kubernetes.Version = fmt.Sprintf("v%s", kcp.Spec.Version)
+			// Tolerate version strings without a "v" prefix: prepend it if it's not there
+			if !strings.HasPrefix(kcp.Spec.Version, "v") {
+				tcp.Spec.Kubernetes.Version = fmt.Sprintf("v%s", kcp.Spec.Version)
+			} else {
+				tcp.Spec.Kubernetes.Version = kcp.Spec.Version
+			}
 			// Kamaji addons and CoreDNS overrides
 			tcp.Spec.Addons = kcp.Spec.Addons.AddonsSpec
 			if kcp.Spec.Addons.CoreDNS != nil {


### PR DESCRIPTION
When using ClusterClasses, `Version` is propagated from `cluster.Spec.Topology` into the `kamajicontrolplane.Spec` with a "v" prefix and then Kamaji complains about the wrong version format. See CAPI defaulting webhook https://github.com/kubernetes-sigs/cluster-api/blob/main/internal/webhooks/cluster.go#L100