### PR TITLE
Omit empty dataStoreName

### DIFF
--- a/api/v1alpha1/kamajicontrolplane_types.go
+++ b/api/v1alpha1/kamajicontrolplane_types.go
@@ -110,7 +110,7 @@ type DeploymentComponent struct {
 type KamajiControlPlaneFields struct {
 	// The Kamaji DataStore to use for the given TenantControlPlane.
 	// Retrieve the list of the allowed ones by issuing "kubectl get datastores.kamaji.clastix.io".
-	DataStoreName string `json:"dataStoreName"`
+	DataStoreName string `json:"dataStoreName,omitempty"`
 	// The addons that must be managed by Kamaji, such as CoreDNS, kube-proxy, and konnectivity.
 	Addons AddonsSpec `json:"addons,omitempty"`
 	// List of the admission controllers to configure for the TenantControlPlane kube-apiserver.

--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -6532,7 +6532,6 @@ spec:
                 description: Version defines the desired Kubernetes version.
                 type: string
             required:
-            - dataStoreName
             - version
             type: object
           status:
@@ -13181,8 +13180,6 @@ spec:
                                 type: object
                             type: object
                         type: object
-                    required:
-                    - dataStoreName
                     type: object
                 required:
                 - spec

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -6819,7 +6819,6 @@ spec:
                 description: Version defines the desired Kubernetes version.
                 type: string
             required:
-            - dataStoreName
             - version
             type: object
           status:

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
@@ -6920,8 +6920,6 @@ spec:
                                 type: object
                             type: object
                         type: object
-                    required:
-                    - dataStoreName
                     type: object
                 required:
                 - spec


### PR DESCRIPTION
This parameter should be optional according to this https://kamaji.clastix.io/reference/api/#tenantcontrolplanespec. Default is used  when not provided, see https://github.com/clastix/kamaji/blob/master/controllers/tenantcontrolplane_controller.go#L305 and https://github.com/clastix/kamaji/blob/master/cmd/manager/cmd.go#L259