### PR TITLE
fix(controller): Fix check for existing controlPlaneEndpoint in clusters

### DIFF
--- a/controllers/kamajicontrolplane_controller_cluster_patch.go
+++ b/controllers/kamajicontrolplane_controller_cluster_patch.go
@@ -131,7 +131,12 @@ func (r *KamajiControlPlaneReconciler) checkGenericCluster(ctx context.Context, 
 		return errors.Wrap(err, fmt.Sprintf("cannot retrieve the %s resource", gkc.GetKind()))
 	}
 
-	controlPlaneEndpoint := gkc.Object["spec"].(map[string]interface{})["controlPlaneEndpoint"].(map[string]interface{}) //nolint:forcetypeassert
+	controlPlaneEndpointUn := gkc.Object["spec"].(map[string]interface{})["controlPlaneEndpoint"] //nolint:forcetypeassert
+	if controlPlaneEndpointUn == nil {
+		return *NewUnmanagedControlPlaneAddressError(gkc.GetKind())
+	}
+
+	controlPlaneEndpoint := controlPlaneEndpointUn.(map[string]interface{}) //nolint:forcetypeassert
 
 	cpHost, cpPort := controlPlaneEndpoint["host"].(string), controlPlaneEndpoint["port"].(int64) //nolint:forcetypeassert
 


### PR DESCRIPTION
Hello again! 

This fixes a small problem while deploying a vSphere cluster with this operator. 
`.Spec.controlPlaneEndpoint` is initially not set at all, therefore this check previously resulted in a `panic: interface conversion: interface {} is nil, not map[string]interface {}`.

This PR fixes this problem.
This is kinda a follow-up for #91, @hexchen and I are working at the same company.