### PR TITLE
fix: nil pointer dereference for ExternalClusterReference

### DIFF
--- a/controllers/externalclusterreference_controller.go
+++ b/controllers/externalclusterreference_controller.go
@@ -127,9 +127,14 @@ func (r *ExternalClusterReferenceReconciler) SetupWithManager(mgr ctrl.Manager) 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Secret{}).
 		Watches(&v1alpha1.KamajiControlPlane{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
+			kcp := object.(*v1alpha1.KamajiControlPlane) //nolint:forcetypeassert
+			if kcp.Spec.Deployment.ExternalClusterReference == nil {
+				return nil
+			}
+
 			var requests []reconcile.Request
 
-			for _, secret := range r.getSecretFromKamajiControlPlaneReferences(ctx, object.(*v1alpha1.KamajiControlPlane)) { //nolint:forcetypeassert
+			for _, secret := range r.getSecretFromKamajiControlPlaneReferences(ctx, kcp) {
 				requests = append(requests, reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Namespace: secret.Namespace,


### PR DESCRIPTION
When running the Kamaji Control Plane provider with the ExternalClusterReference feature gate enabled, a nil pointer dereference was occurring due to a missing check.