### PR TITLE
feat: support optional infra cluster via feature flag

### DIFF
--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -13477,7 +13477,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --feature-gates=ExternalClusterReference=${CACPPK_EXTERNAL_CLUSTER_REFERENCE:=false},ExternalClusterReferenceCrossNamespace=${CACPPK_EXTERNAL_CLUSTER_REFERENCE_CROSS_NAMESPACE:=false}
+        - --feature-gates=ExternalClusterReference=${CACPPK_EXTERNAL_CLUSTER_REFERENCE:=false},ExternalClusterReferenceCrossNamespace=${CACPPK_EXTERNAL_CLUSTER_REFERENCE_CROSS_NAMESPACE:=false},SkipInfraClusterPatch=${CACPPK_SKIP_INFRA_CLUSTER_PATCH:=false}
         command:
         - /manager
         image: docker.io/clastix/cluster-api-control-plane-provider-kamaji:v0.12.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        - "--feature-gates=ExternalClusterReference=${CACPPK_EXTERNAL_CLUSTER_REFERENCE:=false},ExternalClusterReferenceCrossNamespace=${CACPPK_EXTERNAL_CLUSTER_REFERENCE_CROSS_NAMESPACE:=false}"
+        - "--feature-gates=ExternalClusterReference=${CACPPK_EXTERNAL_CLUSTER_REFERENCE:=false},ExternalClusterReferenceCrossNamespace=${CACPPK_EXTERNAL_CLUSTER_REFERENCE_CROSS_NAMESPACE:=false},SkipInfraClusterPatch=${CACPPK_SKIP_INFRA_CLUSTER_PATCH:=false}"
         image: controller:latest
         name: manager
         securityContext:

--- a/main.go
+++ b/main.go
@@ -63,6 +63,11 @@ func main() {
 			LockToDefault: false,
 			PreRelease:    featuregate.Alpha,
 		},
+		features.SkipInfraClusterPatch: {
+			Default:       false,
+			LockToDefault: false,
+			PreRelease:    featuregate.Alpha,
+		},
 	}); err != nil {
 		setupLog.Error(err, "unable to add feature gates")
 		os.Exit(1)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -11,4 +11,7 @@ const (
 	// ExternalClusterReferenceCrossNamespace allows deploying Tenant Control Plane pods to a different cluster from the Management one.
 	// It supports referencing a kubeconfig available in a different Namespace than the KamajiControlPlane.
 	ExternalClusterReferenceCrossNamespace = "ExternalClusterReferenceCrossNamespace"
+
+	// SkipInfraClusterPatch bypasses patching the InfraCluster with the control-plane endpoint.
+	SkipInfraClusterPatch = "SkipInfraClusterPatch"
 )


### PR DESCRIPTION
## Description

Support was added for the `controlPlaneEndpoint` field in #137. 

This PR builds upon that work to support making the infrastructure cluster fully optional. 

We do this by introducing a feature flag `SkipInfraClusterPatch` that when enabled will bypass patching of the infrastructure cluster.