### PR TITLE
Fix: CrossNamespace remotecluster reference is not supported

### DIFF
--- a/controllers/kamajicontrolplane_controller_externalreference.go
+++ b/controllers/kamajicontrolplane_controller_externalreference.go
@@ -31,8 +31,7 @@ var (
 
 //nolint:cyclop
 func (r *KamajiControlPlaneReconciler) extractRemoteClient(ctx context.Context, kcp v1alpha1.KamajiControlPlane) (client.Client, error) { //nolint:ireturn
-	if !r.FeatureGates.Enabled(features.ExternalClusterReference) &&
-		!r.FeatureGates.Enabled(features.ExternalClusterReferenceCrossNamespace) {
+	if !r.FeatureGates.Enabled(features.ExternalClusterReference)  {
 		return nil, ErrExternalClusterReferenceNotEnabled
 	}
 

--- a/controllers/kamajicontrolplane_controller_externalreference.go
+++ b/controllers/kamajicontrolplane_controller_externalreference.go
@@ -36,7 +36,8 @@ func (r *KamajiControlPlaneReconciler) extractRemoteClient(ctx context.Context, 
 		return nil, ErrExternalClusterReferenceNotEnabled
 	}
 
-	if r.FeatureGates.Enabled(features.ExternalClusterReference) &&
+	if r.FeatureGates.Enabled(features.ExternalClusterReference) && 
+		!r.FeatureGates.Enabled(features.ExternalClusterReferenceCrossNamespace) &&
 		kcp.Spec.Deployment.ExternalClusterReference.KubeconfigSecretNamespace != "" &&
 		kcp.Spec.Deployment.ExternalClusterReference.KubeconfigSecretNamespace != kcp.Namespace {
 		return nil, ErrExternalClusterReferenceCrossNamespaceReference


### PR DESCRIPTION
Modifications Made:
1. ExternalClusterReference not enabled should be only based on single feature flag i.e ExternalClusterReference
2. Added one more condition for CrossNamespaceReference. If CrossNamespaceReference is not enabled then only validate for namespace value match with KCP namespace.