### PR TITLE
feat: dynamic infrastructure clusters patching

### DIFF
--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -13479,7 +13479,8 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --feature-gates=ExternalClusterReference=${CACPPK_EXTERNAL_CLUSTER_REFERENCE:=false},ExternalClusterReferenceCrossNamespace=${CACPPK_EXTERNAL_CLUSTER_REFERENCE_CROSS_NAMESPACE:=false},SkipInfraClusterPatch=${CACPPK_SKIP_INFRA_CLUSTER_PATCH:=false}
+        - --feature-gates=DynamicInfrastructureClusterPatch=${CACPPK_DYNAMIC_INFRASTRUCTURE_CLUSTER_PATCH:=false},ExternalClusterReference=${CACPPK_EXTERNAL_CLUSTER_REFERENCE:=false},ExternalClusterReferenceCrossNamespace=${CACPPK_EXTERNAL_CLUSTER_REFERENCE_CROSS_NAMESPACE:=false},SkipInfraClusterPatch=${CACPPK_SKIP_INFRA_CLUSTER_PATCH:=false}
+        - --dynamic-infrastructure-clusters=${CACPPK_INFRASTRUCTURE_CLUSTERS:= }
         command:
         - /manager
         image: docker.io/clastix/cluster-api-control-plane-provider-kamaji:v0.13.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,8 @@ spec:
         - /manager
         args:
         - --leader-elect
-        - "--feature-gates=ExternalClusterReference=${CACPPK_EXTERNAL_CLUSTER_REFERENCE:=false},ExternalClusterReferenceCrossNamespace=${CACPPK_EXTERNAL_CLUSTER_REFERENCE_CROSS_NAMESPACE:=false},SkipInfraClusterPatch=${CACPPK_SKIP_INFRA_CLUSTER_PATCH:=false}"
+        - "--feature-gates=DynamicInfrastructureClusterPatch=${CACPPK_DYNAMIC_INFRASTRUCTURE_CLUSTER_PATCH:=false},ExternalClusterReference=${CACPPK_EXTERNAL_CLUSTER_REFERENCE:=false},ExternalClusterReferenceCrossNamespace=${CACPPK_EXTERNAL_CLUSTER_REFERENCE_CROSS_NAMESPACE:=false},SkipInfraClusterPatch=${CACPPK_SKIP_INFRA_CLUSTER_PATCH:=false}"
+        - "--dynamic-infrastructure-clusters=${CACPPK_INFRASTRUCTURE_CLUSTERS:= }"
         image: controller:latest
         name: manager
         securityContext:

--- a/controllers/kamajicontrolplane_controller.go
+++ b/controllers/kamajicontrolplane_controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/component-base/featuregate"
@@ -40,6 +41,7 @@ type KamajiControlPlaneReconciler struct {
 	ExternalClusterReferenceStore externalclusterreference.Store
 	FeatureGates                  featuregate.FeatureGate
 	MaxConcurrentReconciles       int
+	DynamicInfrastructureClusters sets.Set[string]
 
 	client client.Client
 }

--- a/controllers/kamajicontrolplane_controller_cluster_patch.go
+++ b/controllers/kamajicontrolplane_controller_cluster_patch.go
@@ -110,6 +110,10 @@ func (r *KamajiControlPlaneReconciler) patchCluster(ctx context.Context, cluster
 	case "VSphereCluster":
 		return r.checkOrPatchGenericCluster(ctx, cluster, endpoint, port)
 	default:
+		if r.DynamicInfrastructureClusters.Has(cluster.Spec.InfrastructureRef.Kind) {
+			return r.patchGenericCluster(ctx, cluster, endpoint, port, false)
+		}
+
 		return errors.New("unsupported infrastructure provider")
 	}
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -14,4 +14,8 @@ const (
 
 	// SkipInfraClusterPatch bypasses patching the InfraCluster with the control-plane endpoint.
 	SkipInfraClusterPatch = "SkipInfraClusterPatch"
+
+	// DynamicInfrastructureClusterPatch allows patching any generic InfraCluster with the control-plane endpoint
+	// provided by Kamaji.
+	DynamicInfrastructureClusterPatch = "DynamicInfrastructureClusterPatch"
 )


### PR DESCRIPTION
This feature request introduces a feature togglable via the Feature Flag `DynamicInfrastructureClusterPatch` which allows patching any Infrastructure Cluster specified in the CLI flag `--infrastructure-clusters` which accepts a comma-separated list of Kubernetes API object kinds.

This feature is useful for developers aiming to integrate Kamaji within their organizations where a Cluster API infrastructure provider is not public.

Upon installation, a proper RBAC must be addressed here, otherwise patching would require a `*` scope which isn't good from a threat modeling perspective.