### PR TITLE
ci: fix token permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,22 +6,27 @@ on:
   pull_request:
     branches: [ "*" ]
 
+permissions:
+  contents: read
+
 jobs:
   commit_lint:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v2
-        with:
-          firstParent: true
+      - uses: actions/checkout@v4
+      - uses: wagoid/commitlint-github-action@v6
   golangci:
     name: lint
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: Run golangci-lint
@@ -33,10 +38,8 @@ jobs:
     name: diff
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - run: make release

--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -5,20 +5,23 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   docker-ci:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
             docker.io/${{ github.repository }}
@@ -29,13 +32,13 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,arm
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
 
@@ -48,7 +51,7 @@ jobs:
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
 
       - name: Login to docker.io Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: docker.io
           username: ${{ secrets.DOCKER_IO_USERNAME }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,9 @@ on:
       - "master"
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   create-cluster:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,17 +5,22 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: tag release
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
           token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Going over the [Scorecard report](https://securityscorecards.dev/viewer/?uri=github.com/clastix/cluster-api-control-plane-provider-kamaji) and fixing some things.

**Reason**
detected GitHub workflow tokens with excessive permissions

**Details**
Warn: no topLevel permission defined: .github/workflows/ci.yaml:1
Warn: no topLevel permission defined: .github/workflows/docker-ci.yaml:1
Warn: no topLevel permission defined: .github/workflows/e2e.yaml:1
Warn: no topLevel permission defined: .github/workflows/release.yaml:1
Info: no jobLevel write permissions found

I used https://app.stepsecurity.io/secureworkflow to verify the permissions as recommended in the documentation.
