### PR TITLE
docs: remove deprecated flag for kube-apiserver in provider docs

### DIFF
--- a/docs/providers-aws.md
+++ b/docs/providers-aws.md
@@ -53,9 +53,6 @@ metadata:
   name: kamaji-quickstart-control-plane
   namespace: default
 spec:
-  apiServer:
-    extraArgs:
-      - --cloud-provider=external
   controllerManager:
     extraArgs:
       - --cloud-provider=external

--- a/docs/providers-azure.md
+++ b/docs/providers-azure.md
@@ -79,9 +79,6 @@ metadata:
   name: kamaji-quickstart-control-plane
   namespace: default
 spec:
-  apiServer:
-    extraArgs:
-      - --cloud-provider=external
   controllerManager:
     extraArgs:
       - --cloud-provider=external

--- a/docs/providers-hetzner.md
+++ b/docs/providers-hetzner.md
@@ -260,9 +260,6 @@ metadata:
   name: workload-control-plane
   namespace: default
 spec:
-  apiServer:
-    extraArgs:
-      - --cloud-provider=external
   controllerManager:
     extraArgs:
       - --cloud-provider=external

--- a/docs/providers-nutanix.md
+++ b/docs/providers-nutanix.md
@@ -53,9 +53,6 @@ metadata:
   name: kamaji-nutanix-127
   namespace: default
 spec:
-  apiServer:
-    extraArgs:
-      - --cloud-provider=external
   controllerManager:
     extraArgs:
       - --cloud-provider=external

--- a/docs/providers-openstack.md
+++ b/docs/providers-openstack.md
@@ -100,9 +100,6 @@ spec:
   controllerManager:
     extraArgs:
     - --cloud-provider=external
-  apiServer:
-    extraArgs:
-    - --cloud-provider=external
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/docs/providers-vsphere.md
+++ b/docs/providers-vsphere.md
@@ -56,9 +56,6 @@ metadata:
   name: kamaji-vsphere-125
   namespace: default
 spec:
-  apiServer:
-    extraArgs:
-      - --cloud-provider=external
   controllerManager:
     extraArgs:
       - --cloud-provider=external


### PR DESCRIPTION
Fixes #199 

- Removed `--cloud-provider=external`from apiServer args which is no longer available since Kubernetes 1.33