### PR TITLE
remove deprecated flag for kube-apiserver in templates

### DIFF
--- a/templates/vsphere/capi-kamaji-vsphere-autoscaler-template.yaml
+++ b/templates/vsphere/capi-kamaji-vsphere-autoscaler-template.yaml
@@ -50,9 +50,6 @@ metadata:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
     cni: calico
 spec:
-  apiServer:
-    extraArgs:
-      - --cloud-provider=external
   controllerManager:
     extraArgs:
       - --cloud-provider=external

--- a/templates/vsphere/capi-kamaji-vsphere-class-template.yaml
+++ b/templates/vsphere/capi-kamaji-vsphere-class-template.yaml
@@ -51,9 +51,6 @@ spec:
         coreDNS: {}
         konnectivity: {}
         kubeProxy: {}
-      apiServer:
-        extraArgs:
-        - --cloud-provider=external
       controllerManager:
         extraArgs:
         - --cloud-provider=external

--- a/templates/vsphere/capi-kamaji-vsphere-dhcp-template.yaml
+++ b/templates/vsphere/capi-kamaji-vsphere-dhcp-template.yaml
@@ -49,9 +49,6 @@ metadata:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
     cni: calico
 spec:
-  apiServer:
-    extraArgs:
-      - --cloud-provider=external
   controllerManager:
     extraArgs:
       - --cloud-provider=external

--- a/templates/vsphere/capi-kamaji-vsphere-template-ccm.yaml
+++ b/templates/vsphere/capi-kamaji-vsphere-template-ccm.yaml
@@ -49,9 +49,6 @@ metadata:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
     cni: calico
 spec:
-  apiServer:
-    extraArgs:
-      - --cloud-provider=external
   controllerManager:
     extraArgs:
       - --cloud-provider=external

--- a/templates/vsphere/capi-kamaji-vsphere-template-csi.yaml
+++ b/templates/vsphere/capi-kamaji-vsphere-template-csi.yaml
@@ -49,9 +49,6 @@ metadata:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
     cni: calico
 spec:
-  apiServer:
-    extraArgs:
-      - --cloud-provider=external
   controllerManager:
     extraArgs:
       - --cloud-provider=external

--- a/templates/vsphere/capi-kamaji-vsphere-template.yaml
+++ b/templates/vsphere/capi-kamaji-vsphere-template.yaml
@@ -49,9 +49,6 @@ metadata:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
     cni: calico
 spec:
-  apiServer:
-    extraArgs:
-      - --cloud-provider=external
   controllerManager:
     extraArgs:
       - --cloud-provider=external


### PR DESCRIPTION
close #201 