### PR TITLE
fix: use fallback for dnsServiceIPs

### DIFF
--- a/controllers/kamajicontrolplane_controller_tcp.go
+++ b/controllers/kamajicontrolplane_controller_tcp.go
@@ -99,9 +99,6 @@ func (r *KamajiControlPlaneReconciler) createOrUpdateTenantControlPlane(ctx cont
 				}
 
 				tcp.Spec.Addons.CoreDNS = kcp.Spec.Addons.CoreDNS.AddonSpec
-			} else {
-				tcp.Spec.Addons.CoreDNS = nil
-				tcp.Spec.NetworkProfile.DNSServiceIPs = nil
 			}
 			// Kamaji specific options
 			tcp.Spec.DataStore = kcp.Spec.DataStoreName


### PR DESCRIPTION
Sorry, missed this during testing. The KCP has the field but it's not on the TCP because the value gets cleared in an else block.
