### PR TITLE
feat(rbac): add permissions over metal3clusters

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -57,6 +57,7 @@ rules:
   - hetznerclusters
   - ionoscloudclusters
   - kubevirtclusters
+  - metal3clusters
   - nutanixclusters
   - openstackclusters
   - packetclusters
@@ -76,12 +77,6 @@ rules:
   - packetclusters/status
   verbs:
   - patch
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - metal3clusters
-  verbs:
-  - get
 - apiGroups:
   - kamaji.clastix.io
   resources:


### PR DESCRIPTION
Currently when deploying the provider using Metal3 for infrastructure requires manually editing kamaji-manager cluster role because of missing permissions.

Adding the permissions required over `metal3clusters` CRD.