### PR TITLE
Feat/externalcluster default naming

### DIFF
--- a/api/v1alpha1/kamajicontrolplane_types.go
+++ b/api/v1alpha1/kamajicontrolplane_types.go
@@ -184,6 +184,9 @@ type ExternalClusterReference struct {
 	KubeconfigSecretNamespace string `json:"kubeconfigSecretNamespace,omitempty"`
 	// The Namespace where the resulting TenantControlPlane must be deployed to.
 	DeploymentNamespace string `json:"deploymentNamespace"`
+	// Set tenantControlPlane name to corresponding kamajiControlPlane's name instead of "kcp-<KCP_UID>".
+	// May lead to collisions in external cluster, use with care.
+	KeepDefaultName bool `json:"keepDefaultName,omitempty"`
 }
 
 // KamajiControlPlaneStatus defines the observed state of KamajiControlPlane.

--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -1527,7 +1527,7 @@ spec:
                       keepDefaultName:
                         description: Set tenantControlPlane name to corresponding kamajiControlPlane's name instead of "kcp-<KCP_UID>".
                           May lead to collisions in external cluster, use with care.
-                        type: bool
+                        type: boolean
                       deploymentNamespace:
                         description: The Namespace where the resulting TenantControlPlane must be deployed to.
                         type: string
@@ -8251,7 +8251,7 @@ spec:
                               keepDefaultName:
                                 description: Set tenantControlPlane name to corresponding kamajiControlPlane's name instead of "kcp-<KCP_UID>".
                                   May lead to collisions in external cluster, use with care.
-                                type: bool
+                                type: boolean
                               deploymentNamespace:
                                 description: The Namespace where the resulting TenantControlPlane must be deployed to.
                                 type: string

--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -1524,6 +1524,10 @@ spec:
                       When this value is nil, the Cluster API management cluster will be used as a target.
                       The ExternalClusterReference feature gate must be enabled with one of the available flags.
                     properties:
+                      keepDefaultName:
+                        description: Set tenantControlPlane name to corresponding kamajiControlPlane's name instead of "kcp-<KCP_UID>".
+                          May lead to collisions in external cluster, use with care.
+                        type: bool
                       deploymentNamespace:
                         description: The Namespace where the resulting TenantControlPlane must be deployed to.
                         type: string
@@ -8244,6 +8248,10 @@ spec:
                               When this value is nil, the Cluster API management cluster will be used as a target.
                               The ExternalClusterReference feature gate must be enabled with one of the available flags.
                             properties:
+                              keepDefaultName:
+                                description: Set tenantControlPlane name to corresponding kamajiControlPlane's name instead of "kcp-<KCP_UID>".
+                                  May lead to collisions in external cluster, use with care.
+                                type: bool
                               deploymentNamespace:
                                 description: The Namespace where the resulting TenantControlPlane must be deployed to.
                                 type: string

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -1572,6 +1572,10 @@ spec:
                       When this value is nil, the Cluster API management cluster will be used as a target.
                       The ExternalClusterReference feature gate must be enabled with one of the available flags.
                     properties:
+                      keepDefaultName:
+                        description: Set tenantControlPlane name to corresponding kamajiControlPlane's name instead of "kcp-<KCP_UID>".
+                          May lead to collisions in external cluster, use with care.
+                        type: bool
                       deploymentNamespace:
                         description: The Namespace where the resulting TenantControlPlane
                           must be deployed to.

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -1575,7 +1575,7 @@ spec:
                       keepDefaultName:
                         description: Set tenantControlPlane name to corresponding kamajiControlPlane's name instead of "kcp-<KCP_UID>".
                           May lead to collisions in external cluster, use with care.
-                        type: bool
+                        type: boolean
                       deploymentNamespace:
                         description: The Namespace where the resulting TenantControlPlane
                           must be deployed to.

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
@@ -1584,6 +1584,10 @@ spec:
                               When this value is nil, the Cluster API management cluster will be used as a target.
                               The ExternalClusterReference feature gate must be enabled with one of the available flags.
                             properties:
+                              keepDefaultName:
+                                description: Set tenantControlPlane name to corresponding kamajiControlPlane's name instead of "kcp-<KCP_UID>".
+                                  May lead to collisions in external cluster, use with care.
+                                type: bool
                               deploymentNamespace:
                                 description: The Namespace where the resulting TenantControlPlane
                                   must be deployed to.

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
@@ -1587,7 +1587,7 @@ spec:
                               keepDefaultName:
                                 description: Set tenantControlPlane name to corresponding kamajiControlPlane's name instead of "kcp-<KCP_UID>".
                                   May lead to collisions in external cluster, use with care.
-                                type: bool
+                                type: boolean
                               deploymentNamespace:
                                 description: The Namespace where the resulting TenantControlPlane
                                   must be deployed to.

--- a/pkg/externalclusterreference/name_generator.go
+++ b/pkg/externalclusterreference/name_generator.go
@@ -25,6 +25,9 @@ func ParseKamajiControlPlaneUIDFromTenantControlPlane(tcp kamajiv1alpha1.TenantC
 }
 
 func GenerateRemoteTenantControlPlaneNames(kcp v1alpha1.KamajiControlPlane) (name string, namespace string) { //nolint:nonamedreturns
+	if kcp.Spec.Deployment.ExternalClusterReference.KeepDefaultName == true {
+		return kcp.GetName(), kcp.Spec.Deployment.ExternalClusterReference.DeploymentNamespace
+	}
 	return RemoteTCPPrefix + string(kcp.UID), kcp.Spec.Deployment.ExternalClusterReference.DeploymentNamespace
 }
 


### PR DESCRIPTION
My implementation of #209 (had to go for the 2nd solution).
Added an option to use externalClusterReference but keep the default naming scheme instead of using "kcp-<KCP_UID> for TCP and other resources. To use this set `externalClusterReference.keepDefaultName: true`.

There is a risk of collisions in the external cluster so it should be used only if absolutely necessary.