### PR TITLE
feat(controller): add virtink infrastructure provider

### DIFF
--- a/controllers/kamajicontrolplane_controller_cluster_patch.go
+++ b/controllers/kamajicontrolplane_controller_cluster_patch.go
@@ -95,6 +95,8 @@ func (r *KamajiControlPlaneReconciler) patchCluster(ctx context.Context, cluster
 		return r.patchGenericCluster(ctx, cluster, endpoint, port, false)
 	case "KubevirtCluster":
 		return r.patchGenericCluster(ctx, cluster, endpoint, port, true)
+	case "VirtinkCluster":
+		return r.patchGenericCluster(ctx, cluster, endpoint, port, true)
 	case "Metal3Cluster":
 		return r.checkGenericCluster(ctx, cluster, endpoint, port)
 	case "NutanixCluster":


### PR DESCRIPTION
[virtink](https://github.com/smartxworks/virtink ) is a solution to deploy micro-vms in Kubernetes. It supports  [ClusterAPI](https://github.com/smartxworks/cluster-api-provider-virtink).

It's a small project but it works very well and coupling it with Kamaji gives great results.

I propose to include it in Kamaji with this PR.