### PR TITLE
fix: removing paused condition as soon as possible

### DIFF
--- a/controllers/kamajicontrolplane_controller.go
+++ b/controllers/kamajicontrolplane_controller.go
@@ -129,6 +129,8 @@ func (r *KamajiControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Extracting conditions, used to update the KamajiControlPlane ones upon the end of the reconciliation.
 	conditions := kcp.Status.Conditions
 
+	meta.RemoveStatusCondition(&conditions, string(kcpv1alpha2.PausedConditionType))
+
 	defer func() {
 		deferErr := r.updateKamajiControlPlaneStatus(ctx, &kcp, func() {
 			kcp.Status.Conditions = conditions
@@ -362,8 +364,6 @@ func (r *KamajiControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		Reason:             availableReason,
 		ObservedGeneration: kcp.Generation,
 	})
-
-	meta.RemoveStatusCondition(&conditions, string(kcpv1alpha2.PausedConditionType))
 
 	if err != nil {
 		if errors.Is(err, ErrEnqueueBack) {


### PR DESCRIPTION
@synthe102 just asking for your review: I think it's safe (and maybe better) to remove the `Paused` condition as soon as possible, rather than waiting for the propagation of other conditions.