### PR TITLE
feat(network): add AdditionalServicePorts to KamajiControlPlane spec

### DIFF
--- a/api/v1alpha2/kamajicontrolplane_types.go
+++ b/api/v1alpha2/kamajicontrolplane_types.go
@@ -124,6 +124,11 @@ type NetworkComponent struct {
 	AdvertiseAddress   string            `json:"advertiseAddress,omitempty"`
 	ServiceLabels      map[string]string `json:"serviceLabels,omitempty"`
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
+	// AdditionalServicePorts adds extra ports to the Service that fronts the
+	// TenantControlPlane Pods. Useful when sidecars (such as a CSR signer)
+	// running alongside the kube-apiserver need to be reachable from tenant
+	// workers through the same Service endpoint.
+	AdditionalServicePorts []kamajiv1alpha1.AdditionalPort `json:"additionalServicePorts,omitempty"`
 	// Configure additional Subject Address Names for the kube-apiserver certificate,
 	// useful if the TenantControlPlane is going to be exposed behind a FQDN with NAT.
 	CertSANs []string `json:"certSANs,omitempty"` //nolint:tagliatelle

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -606,6 +606,13 @@ func (in *NetworkComponent) DeepCopyInto(out *NetworkComponent) {
 			(*out)[key] = val
 		}
 	}
+	if in.AdditionalServicePorts != nil {
+		in, out := &in.AdditionalServicePorts, &out.AdditionalServicePorts
+		*out = make([]v1alpha1.AdditionalPort, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.CertSANs != nil {
 		in, out := &in.CertSANs, &out.CertSANs
 		*out = make([]string, len(*in))

--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -7052,6 +7052,58 @@ spec:
                   serviceType: LoadBalancer
                 description: Configure how the TenantControlPlane should be exposed.
                 properties:
+                  additionalServicePorts:
+                    description: |-
+                      AdditionalServicePorts adds extra ports to the Service that fronts the
+                      TenantControlPlane Pods. Useful when sidecars (such as a CSR signer)
+                      running alongside the kube-apiserver need to be reachable from tenant
+                      workers through the same Service endpoint.
+                    items:
+                      properties:
+                        appProtocol:
+                          description: |-
+                            The application protocol for this port.
+                            This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                            This field follows standard Kubernetes label syntax.
+                            Valid values are either:
+
+                            * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                            RFC-6335 and https://www.iana.org/assignments/service-names).
+                          type: string
+                        name:
+                          description: |-
+                            The name of this port within the Service created by Kamaji.
+                            This must be a DNS_LABEL, must have unique names, and cannot be `kube-apiserver`, or `konnectivity-server`.
+                          type: string
+                        port:
+                          description: The port that will be exposed by this service.
+                          format: int32
+                          type: integer
+                        protocol:
+                          default: TCP
+                          description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                          enum:
+                          - TCP
+                          - UDP
+                          - SCTP
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Number or name of the port to access on the pods of the Tenant Control Plane.
+                            Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                            If this is a string, it will be looked up as a named port in the
+                            target Pod's container ports. If this is not specified, the value
+                            of the 'port' field is used (an identity map).
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - targetPort
+                      type: object
+                    type: array
                   advertiseAddress:
                     description: |-
                       AdvertiseAddress is the address advertised to tenant-side consumers (workers, konnectivity).
@@ -14617,6 +14669,58 @@ spec:
                           serviceType: LoadBalancer
                         description: Configure how the TenantControlPlane should be exposed.
                         properties:
+                          additionalServicePorts:
+                            description: |-
+                              AdditionalServicePorts adds extra ports to the Service that fronts the
+                              TenantControlPlane Pods. Useful when sidecars (such as a CSR signer)
+                              running alongside the kube-apiserver need to be reachable from tenant
+                              workers through the same Service endpoint.
+                            items:
+                              properties:
+                                appProtocol:
+                                  description: |-
+                                    The application protocol for this port.
+                                    This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                    This field follows standard Kubernetes label syntax.
+                                    Valid values are either:
+
+                                    * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                    RFC-6335 and https://www.iana.org/assignments/service-names).
+                                  type: string
+                                name:
+                                  description: |-
+                                    The name of this port within the Service created by Kamaji.
+                                    This must be a DNS_LABEL, must have unique names, and cannot be `kube-apiserver`, or `konnectivity-server`.
+                                  type: string
+                                port:
+                                  description: The port that will be exposed by this service.
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                  enum:
+                                  - TCP
+                                  - UDP
+                                  - SCTP
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the pods of the Tenant Control Plane.
+                                    Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    If this is a string, it will be looked up as a named port in the
+                                    target Pod's container ports. If this is not specified, the value
+                                    of the 'port' field is used (an identity map).
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - name
+                              - port
+                              - targetPort
+                              type: object
+                            type: array
                           advertiseAddress:
                             description: |-
                               AdvertiseAddress is the address advertised to tenant-side consumers (workers, konnectivity).

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -7400,6 +7400,59 @@ spec:
                   serviceType: LoadBalancer
                 description: Configure how the TenantControlPlane should be exposed.
                 properties:
+                  additionalServicePorts:
+                    description: |-
+                      AdditionalServicePorts adds extra ports to the Service that fronts the
+                      TenantControlPlane Pods. Useful when sidecars (such as a CSR signer)
+                      running alongside the kube-apiserver need to be reachable from tenant
+                      workers through the same Service endpoint.
+                    items:
+                      properties:
+                        appProtocol:
+                          description: |-
+                            The application protocol for this port.
+                            This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                            This field follows standard Kubernetes label syntax.
+                            Valid values are either:
+
+                            * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                            RFC-6335 and https://www.iana.org/assignments/service-names).
+                          type: string
+                        name:
+                          description: |-
+                            The name of this port within the Service created by Kamaji.
+                            This must be a DNS_LABEL, must have unique names, and cannot be `kube-apiserver`, or `konnectivity-server`.
+                          type: string
+                        port:
+                          description: The port that will be exposed by this service.
+                          format: int32
+                          type: integer
+                        protocol:
+                          default: TCP
+                          description: The IP protocol for this port. Supports "TCP",
+                            "UDP", and "SCTP".
+                          enum:
+                          - TCP
+                          - UDP
+                          - SCTP
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Number or name of the port to access on the pods of the Tenant Control Plane.
+                            Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                            If this is a string, it will be looked up as a named port in the
+                            target Pod's container ports. If this is not specified, the value
+                            of the 'port' field is used (an identity map).
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - name
+                      - port
+                      - targetPort
+                      type: object
+                    type: array
                   advertiseAddress:
                     description: |-
                       AdvertiseAddress is the address advertised to tenant-side consumers (workers, konnectivity).

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
@@ -7491,6 +7491,60 @@ spec:
                         description: Configure how the TenantControlPlane should be
                           exposed.
                         properties:
+                          additionalServicePorts:
+                            description: |-
+                              AdditionalServicePorts adds extra ports to the Service that fronts the
+                              TenantControlPlane Pods. Useful when sidecars (such as a CSR signer)
+                              running alongside the kube-apiserver need to be reachable from tenant
+                              workers through the same Service endpoint.
+                            items:
+                              properties:
+                                appProtocol:
+                                  description: |-
+                                    The application protocol for this port.
+                                    This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                    This field follows standard Kubernetes label syntax.
+                                    Valid values are either:
+
+                                    * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                    RFC-6335 and https://www.iana.org/assignments/service-names).
+                                  type: string
+                                name:
+                                  description: |-
+                                    The name of this port within the Service created by Kamaji.
+                                    This must be a DNS_LABEL, must have unique names, and cannot be `kube-apiserver`, or `konnectivity-server`.
+                                  type: string
+                                port:
+                                  description: The port that will be exposed by this
+                                    service.
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: The IP protocol for this port. Supports
+                                    "TCP", "UDP", and "SCTP".
+                                  enum:
+                                  - TCP
+                                  - UDP
+                                  - SCTP
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the pods of the Tenant Control Plane.
+                                    Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    If this is a string, it will be looked up as a named port in the
+                                    target Pod's container ports. If this is not specified, the value
+                                    of the 'port' field is used (an identity map).
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - name
+                              - port
+                              - targetPort
+                              type: object
+                            type: array
                           advertiseAddress:
                             description: |-
                               AdvertiseAddress is the address advertised to tenant-side consumers (workers, konnectivity).

--- a/controllers/kamajicontrolplane_controller_tcp.go
+++ b/controllers/kamajicontrolplane_controller_tcp.go
@@ -150,6 +150,7 @@ func (r *KamajiControlPlaneReconciler) createOrUpdateTenantControlPlane(ctx cont
 			tcp.Spec.ControlPlane.Service.ServiceType = kcp.Spec.Network.ServiceType
 			tcp.Spec.ControlPlane.Service.AdditionalMetadata.Labels = kcp.Spec.Network.ServiceLabels
 			tcp.Spec.ControlPlane.Service.AdditionalMetadata.Annotations = kcp.Spec.Network.ServiceAnnotations
+			tcp.Spec.ControlPlane.Service.AdditionalPorts = kcp.Spec.Network.AdditionalServicePorts
 
 			for _, i := range kcp.Spec.Network.CertSANs {
 				// validating CertSANs as soon as possible to avoid github.com/clastix/kamaji/issues/679:


### PR DESCRIPTION
## What this PR does

Adds `KamajiControlPlane.spec.network.additionalServicePorts` and propagates it into the underlying `TenantControlPlane.spec.controlPlane.service.additionalPorts`, which Kamaji has supported since v1.0.1+ (clastix/kamaji#999).

## Why

When operators run an extra container alongside the kube-apiserver in the TenantControlPlane Pod — for example [clastix/talos-csr-signer](https://github.com/clastix/talos-csr-signer) implementing the Talos `trustd` gRPC service on port 50001 — workers need to reach the sidecar through the same Service endpoint that fronts the apiserver. The downstream Kamaji CRD already exposes this via `controlPlane.service.additionalPorts`; this PR surfaces the same knob on the CAPI-managed `KamajiControlPlane` resource so users don't have to drop down to managing TenantControlPlane directly.

The motivating downstream consumer is the Cozystack Talos worker migration in cozystack/cozystack#2610.

## Notes

- Bumps `github.com/clastix/kamaji` to a version that ships the `AdditionalPort` type and the `ServiceSpec.AdditionalPorts` field (introduced upstream in late 2025).
- `make generate manifests` regenerated.
- Existing controller tests pass; no new tests added since the new field is a pass-through (`tcp.Spec.ControlPlane.Service.AdditionalPorts = kcp.Spec.Network.AdditionalServicePorts`).
