### PR TITLE
fix: evaluating rule failure for loadBalancerConfig

### DIFF
--- a/api/v1alpha2/kamajicontrolplane_types.go
+++ b/api/v1alpha2/kamajicontrolplane_types.go
@@ -84,7 +84,6 @@ type IngressComponent struct {
 
 // LoadBalancerConfig is used when the KamajiControlPlane is exposed using a LoadBalancer service type.
 // +kubebuilder:validation:XValidation:rule="has(self.loadBalancerClass) == has(oldSelf.loadBalancerClass)",message="LoadBalancerClass cannot be set or unset at runtime"
-
 type LoadBalancerConfig struct {
 	// LoadBalancerSourceRanges restricts the IP ranges that can access
 	// the LoadBalancer type Service. This field defines a list of IP

--- a/api/v1alpha2/kamajicontrolplane_types.go
+++ b/api/v1alpha2/kamajicontrolplane_types.go
@@ -83,6 +83,8 @@ type IngressComponent struct {
 }
 
 // LoadBalancerConfig is used when the KamajiControlPlane is exposed using a LoadBalancer service type.
+// +kubebuilder:validation:XValidation:rule="has(self.loadBalancerClass) == has(oldSelf.loadBalancerClass)",message="LoadBalancerClass cannot be set or unset at runtime"
+
 type LoadBalancerConfig struct {
 	// LoadBalancerSourceRanges restricts the IP ranges that can access
 	// the LoadBalancer type Service. This field defines a list of IP
@@ -101,7 +103,6 @@ type LoadBalancerConfig struct {
 
 // +kubebuilder:validation:XValidation:rule="!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerSourceRanges) || (size(self.loadBalancerConfig.loadBalancerSourceRanges) == 0 || self.serviceType == 'LoadBalancer')", message="LoadBalancerSourceRanges are supported only with LoadBalancer service type"
 // +kubebuilder:validation:XValidation:rule="!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerClass) || self.serviceType == 'LoadBalancer'", message="LoadBalancerClass is supported only with LoadBalancer service type"
-// +kubebuilder:validation:XValidation:rule="self.serviceType != 'LoadBalancer' || (oldSelf.serviceType != 'LoadBalancer' && self.serviceType == 'LoadBalancer') || !has(self.loadBalancerConfig) || has(self.loadBalancerConfig) && has(self.loadBalancerConfig.loadBalancerClass) == has(oldSelf.loadBalancerConfig.loadBalancerClass)",message="LoadBalancerClass cannot be set or unset at runtime"
 
 type NetworkComponent struct {
 	// Optional configuration for the LoadBalancer service that exposes the Kamaji control plane.

--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -7236,6 +7236,9 @@ spec:
                           type: string
                         type: array
                     type: object
+                    x-kubernetes-validations:
+                    - message: LoadBalancerClass cannot be set or unset at runtime
+                      rule: has(self.loadBalancerClass) == has(oldSelf.loadBalancerClass)
                   serviceAddress:
                     description: |-
                       This field can be used in case of pre-assigned address, such as a VIP,
@@ -7263,8 +7266,6 @@ spec:
                   rule: '!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerSourceRanges) || (size(self.loadBalancerConfig.loadBalancerSourceRanges) == 0 || self.serviceType == ''LoadBalancer'')'
                 - message: LoadBalancerClass is supported only with LoadBalancer service type
                   rule: '!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerClass) || self.serviceType == ''LoadBalancer'''
-                - message: LoadBalancerClass cannot be set or unset at runtime
-                  rule: self.serviceType != 'LoadBalancer' || (oldSelf.serviceType != 'LoadBalancer' && self.serviceType == 'LoadBalancer') || !has(self.loadBalancerConfig) || has(self.loadBalancerConfig) && has(self.loadBalancerConfig.loadBalancerClass) == has(oldSelf.loadBalancerConfig.loadBalancerClass)
               registry:
                 default: registry.k8s.io
                 description: |-
@@ -14853,6 +14854,9 @@ spec:
                                   type: string
                                 type: array
                             type: object
+                            x-kubernetes-validations:
+                            - message: LoadBalancerClass cannot be set or unset at runtime
+                              rule: has(self.loadBalancerClass) == has(oldSelf.loadBalancerClass)
                           serviceAddress:
                             description: |-
                               This field can be used in case of pre-assigned address, such as a VIP,
@@ -14880,8 +14884,6 @@ spec:
                           rule: '!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerSourceRanges) || (size(self.loadBalancerConfig.loadBalancerSourceRanges) == 0 || self.serviceType == ''LoadBalancer'')'
                         - message: LoadBalancerClass is supported only with LoadBalancer service type
                           rule: '!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerClass) || self.serviceType == ''LoadBalancer'''
-                        - message: LoadBalancerClass cannot be set or unset at runtime
-                          rule: self.serviceType != 'LoadBalancer' || (oldSelf.serviceType != 'LoadBalancer' && self.serviceType == 'LoadBalancer') || !has(self.loadBalancerConfig) || has(self.loadBalancerConfig) && has(self.loadBalancerConfig.loadBalancerClass) == has(oldSelf.loadBalancerConfig.loadBalancerClass)
                       registry:
                         default: registry.k8s.io
                         description: |-

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -7588,6 +7588,9 @@ spec:
                           type: string
                         type: array
                     type: object
+                    x-kubernetes-validations:
+                    - message: LoadBalancerClass cannot be set or unset at runtime
+                      rule: has(self.loadBalancerClass) == has(oldSelf.loadBalancerClass)
                   serviceAddress:
                     description: |-
                       This field can be used in case of pre-assigned address, such as a VIP,
@@ -7621,11 +7624,6 @@ spec:
                     type
                   rule: '!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerClass)
                     || self.serviceType == ''LoadBalancer'''
-                - message: LoadBalancerClass cannot be set or unset at runtime
-                  rule: self.serviceType != 'LoadBalancer' || (oldSelf.serviceType
-                    != 'LoadBalancer' && self.serviceType == 'LoadBalancer') || !has(self.loadBalancerConfig)
-                    || has(self.loadBalancerConfig) && has(self.loadBalancerConfig.loadBalancerClass)
-                    == has(oldSelf.loadBalancerConfig.loadBalancerClass)
               registry:
                 default: registry.k8s.io
                 description: |-

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
@@ -7683,6 +7683,10 @@ spec:
                                   type: string
                                 type: array
                             type: object
+                            x-kubernetes-validations:
+                            - message: LoadBalancerClass cannot be set or unset at
+                                runtime
+                              rule: has(self.loadBalancerClass) == has(oldSelf.loadBalancerClass)
                           serviceAddress:
                             description: |-
                               This field can be used in case of pre-assigned address, such as a VIP,
@@ -7716,11 +7720,6 @@ spec:
                             service type
                           rule: '!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerClass)
                             || self.serviceType == ''LoadBalancer'''
-                        - message: LoadBalancerClass cannot be set or unset at runtime
-                          rule: self.serviceType != 'LoadBalancer' || (oldSelf.serviceType
-                            != 'LoadBalancer' && self.serviceType == 'LoadBalancer')
-                            || !has(self.loadBalancerConfig) || has(self.loadBalancerConfig)
-                            && has(self.loadBalancerConfig.loadBalancerClass) == has(oldSelf.loadBalancerConfig.loadBalancerClass)
                       registry:
                         default: registry.k8s.io
                         description: |-


### PR DESCRIPTION
Closes #350.

The root cause is due to changes introduced via #198 where a missing check of a pointer caused the CEL validation to fail with an inconsistent error.