### PR TITLE
fix: use TCP deployment selector for KTCP scale subresource

### DIFF
--- a/controllers/kamajicontrolplane_controller.go
+++ b/controllers/kamajicontrolplane_controller.go
@@ -295,7 +295,7 @@ func (r *KamajiControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		err = r.updateKamajiControlPlaneStatus(ctx, &kcp, func() {
 			kcp.Status.ReadyReplicas = ptr.To(tcp.Status.Kubernetes.Deployment.ReadyReplicas)
 			kcp.Status.Replicas = ptr.To(tcp.Status.Kubernetes.Deployment.Replicas)
-			kcp.Status.Selector = ptr.To(metav1.FormatLabelSelector(&metav1.LabelSelector{MatchLabels: kcp.GetLabels()}))
+			kcp.Status.Selector = ptr.To(tcp.Status.Kubernetes.Deployment.Selector)
 			kcp.Status.AvailableReplicas = ptr.To(tcp.Status.Kubernetes.Deployment.AvailableReplicas)
 			kcp.Status.UpToDateReplicas = ptr.To(tcp.Status.Kubernetes.Deployment.UpdatedReplicas)
 			kcp.Status.Version = tcp.Status.Kubernetes.Version.Version


### PR DESCRIPTION
The KTCP scale subresource status.selector was set to the KTCP resource's own labels, which no pods carry. HPA uses this selector to discover pods for metric collection, so it always got zero samples and reported cpu: <unknown>.

Fix by mirroring tcp.Status.Kubernetes.Deployment.Selector, which the TCP controller already derives from the deployment's pod selector.

Fixes #359