### PR TITLE
fix(rbac): grant kubeadm bootstrap SA read on KamajiControlPlane (CAPI v1.14.0)

### DIFF
--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -15370,8 +15370,8 @@ roleRef:
   name: capi-kamaji-capi-kamaji-control-plane-role
 subjects:
 - kind: ServiceAccount
-  name: capi-kubeadm-bootstrap-manager
-  namespace: capi-kubeadm-bootstrap-system
+  name: ${CACPPK_KUBEADM_BOOTSTRAP_SA_NAME:=capi-kubeadm-bootstrap-manager}
+  namespace: ${CACPPK_KUBEADM_BOOTSTRAP_SA_NAMESPACE:=capi-kubeadm-bootstrap-system}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -15363,6 +15363,27 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/part-of: cluster-api-control-plane-provider-kamaji
     cluster.x-k8s.io/provider: kamaji
+  name: capi-kamaji-capi-kamaji-control-plane-kubeadm-bootstrap-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-kamaji-capi-kamaji-control-plane-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-bootstrap-manager
+  namespace: capi-kubeadm-bootstrap-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: cluster-api-control-plane-provider-kamaji
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: cluster-api-control-plane-provider-kamaji
+    cluster.x-k8s.io/provider: kamaji
   name: capi-kamaji-capi-kamaji-control-plane-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/capi_kubeadm_bootstrap_role_binding.yaml
+++ b/config/rbac/capi_kubeadm_bootstrap_role_binding.yaml
@@ -13,7 +13,9 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: capi-kamaji-control-plane-role
+# The ServiceAccount name/namespace default to the values used when the CAPI
+# Kubeadm Bootstrap provider is installed via `clusterctl init`.
 subjects:
   - kind: ServiceAccount
-    name: capi-kubeadm-bootstrap-manager
-    namespace: capi-kubeadm-bootstrap-system
+    name: ${CACPPK_KUBEADM_BOOTSTRAP_SA_NAME:=capi-kubeadm-bootstrap-manager}
+    namespace: ${CACPPK_KUBEADM_BOOTSTRAP_SA_NAMESPACE:=capi-kubeadm-bootstrap-system}

--- a/config/rbac/capi_kubeadm_bootstrap_role_binding.yaml
+++ b/config/rbac/capi_kubeadm_bootstrap_role_binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: cluster-api-control-plane-provider-kamaji
+    app.kubernetes.io/part-of: cluster-api-control-plane-provider-kamaji
+    app.kubernetes.io/managed-by: kustomize
+  name: capi-kamaji-control-plane-kubeadm-bootstrap-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-kamaji-control-plane-role
+subjects:
+  - kind: ServiceAccount
+    name: capi-kubeadm-bootstrap-manager
+    namespace: capi-kubeadm-bootstrap-system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -13,3 +13,6 @@ resources:
 # as well as to read the instance statuses.
 - capi_role.yaml
 - capi_role_binding.yaml
+# Since Cluster API v1.14.0 the kubeadm bootstrap controller reads the
+# KamajiControlPlane to resolve the control-plane version (upstream #13433).
+- capi_kubeadm_bootstrap_role_binding.yaml


### PR DESCRIPTION
As of Cluster API v1.14.0 (kubernetes-sigs/cluster-api#13433) the kubeadm bootstrap controller resolves the control-plane Kubernetes version by reading the object referenced by `Cluster.spec.controlPlaneRef`. When a Cluster uses a KamajiControlPlane, the bootstrap controller issues a `get` on `kamajicontrolplanes.controlplane.cluster.x-k8s.io`, which otherwise fails with:

```
failed to read control plane version: ... kamajicontrolplanes... is forbidden:
User "system:serviceaccount:capi-kubeadm-bootstrap-system:capi-kubeadm-bootstrap-manager"
cannot get resource "kamajicontrolplanes" in API group
"controlplane.cluster.x-k8s.io"
```

The bootstrap controller reads via an APIReader (no `/status`), so the `get/list/watch` rules already present in `capi_role.yaml` are sufficient; this PR binds that same ClusterRole to the kubeadm bootstrap manager ServiceAccount.

Changes:
- New `config/rbac/capi_kubeadm_bootstrap_role_binding.yaml` (ClusterRoleBinding)
- Registered in `config/rbac/kustomization.yaml`
- Rendered into `config/control-plane-components.yaml`

edit: tried to imitate, the labeling already in place; hoping it's ok