### PR TITLE
feat: support OscCluster infrastructure provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The Kamaji Cluster API Control Plane provider documentation is referenced in the
 | [metal-stack](https://github.com/metal-stack/cluster-api-provider-metal-stack) ([technical considerations](docs/providers-metal-stack.md))    | += 0.8.0          |
 | [Nutanix](https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix) ([technical considerations](docs/providers-nutanix.md))       | += 1.2.4          |
 | [OpenStack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack) ([technical considerations](docs/providers-openstack.md))      | += 0.8.0          |
+| [OUTSCALE](https://github.com/outscale/cluster-api-provider-outscale) ([technical considerations](docs/providers-osc.md))                     | += v1.2.0         |
 | [Tinkerbell](https://github.com/tinkerbell/cluster-api-provider-tinkerbell) ([technical considerations](docs/providers-tinkerbell.md))        | += v0.5.2         |
 | [vSphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere) ([technical considerations](docs/providers-vsphere.md))            | += 1.7.0          |
 | [IONOS Cloud](https://github.com/ionos-cloud/cluster-api-provider-ionoscloud) ([technical considerations](docs/providers-ionoscloud.md))      | += v0.3.0         |

--- a/config/control-plane-components.yaml
+++ b/config/control-plane-components.yaml
@@ -15655,6 +15655,7 @@ rules:
   - kubevirtclusters
   - nutanixclusters
   - openstackclusters
+  - oscclusters
   - packetclusters
   - proxmoxclusters
   - tinkerbellclusters

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -59,6 +59,7 @@ rules:
   - kubevirtclusters
   - nutanixclusters
   - openstackclusters
+  - oscclusters
   - packetclusters
   - proxmoxclusters
   - tinkerbellclusters

--- a/controllers/kamajicontrolplane_controller_cluster_patch.go
+++ b/controllers/kamajicontrolplane_controller_cluster_patch.go
@@ -131,6 +131,8 @@ func (r *KamajiControlPlaneReconciler) patchCluster(ctx context.Context, cluster
 		return r.patchGenericCluster(ctx, cluster, endpoint, port, true)
 	case "OpenStackCluster":
 		return r.patchOpenStackCluster(ctx, cluster, endpoint, port)
+	case "OscCluster":
+		return r.patchGenericCluster(ctx, cluster, endpoint, port, false)
 	case "PacketCluster":
 		return r.patchGenericCluster(ctx, cluster, endpoint, port, true)
 	case "ProxmoxCluster":
@@ -163,7 +165,7 @@ func (r *KamajiControlPlaneReconciler) checkOrPatchGenericCluster(ctx context.Co
 	return nil
 }
 
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusters;azureclusters;hetznerclusters;kubevirtclusters;nutanixclusters;packetclusters;ionoscloudclusters,verbs=patch;get;list;watch
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusters;azureclusters;hetznerclusters;kubevirtclusters;nutanixclusters;oscclusters;packetclusters;ionoscloudclusters,verbs=patch;get;list;watch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kubevirtclusters/status;nutanixclusters/status;packetclusters/status,verbs=patch
 
 func (r *KamajiControlPlaneReconciler) patchGenericCluster(ctx context.Context, cluster capiv1beta2.Cluster, endpoint string, port int64, patchStatus bool) error {

--- a/docs/providers-osc.md
+++ b/docs/providers-osc.md
@@ -1,0 +1,156 @@
+# Kamaji and OUTSCALE
+
+The Kamaji Control Plane provider was able to create an _OUTSCALE_ backed Kubernetes cluster by providing Kamaji Control Planes.
+
+```
+NAME                                                      READY  SEVERITY  REASON  SINCE  MESSAGE
+Cluster/capi-quickstart                                   True                     12m
+├─ClusterInfrastructure - OscCluster/capi-quickstart
+├─ControlPlane - KamajiControlPlane/capi-quickstart
+└─Workers
+  └─MachineDeployment/capi-quickstart-md-0                True                     68s
+    └─3 Machines...                                       True                     5m13s  See capi-quickstart-md-0-6blxw-7hkx7, capi-quickstart-md-0-6blxw-9wj6v, ...
+```
+
+## Example manifests
+
+The [Cluster API Provider OUTSCALE](https://github.com/outscale/cluster-api-provider-outscale) (CAPOSC) version must be `>= v1.2.0`, since the `network.disable` field is used to disable the OUTSCALE Load Balancer.
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: capi-quickstart
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 172.16.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: KamajiControlPlane
+    name: capi-quickstart
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: OscCluster
+    name: capi-quickstart
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OscCluster
+metadata:
+  name: capi-quickstart
+  namespace: default
+spec:
+  credentials:
+    fromSecret: cluster-api-provider-outscale
+  network:
+    disable:
+      - loadbalancer
+    bastion:
+      enable: false
+    net:
+      ipRange: 10.0.0.0/16
+    subregionName: eu-west-2a
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha2
+kind: KamajiControlPlane
+metadata:
+  name: capi-quickstart
+  namespace: default
+spec:
+  replicas: 3
+  version: v1.35.7
+  dataStoreName: default
+  addons:
+    coreDNS: {}
+    kubeProxy: {}
+  kubelet:
+    preferredAddressTypes:
+      - InternalIP
+      - ExternalIP
+      - Hostname
+  network:
+    serviceAnnotations:
+      # service.beta.kubernetes.io/osc-load-balancer-internal: "true" # uncomment for an internal LBU
+      service.beta.kubernetes.io/osc-load-balancer-ingress-address: both
+    serviceType: LoadBalancer
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OscMachineTemplate
+metadata:
+  name: capi-quickstart-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      node:
+        image:
+          name: ubuntu-2404-kube-v1.35.7
+        vm:
+          keypairName: my-keypair
+          rootDisk:
+            rootDiskIops: 2000
+            rootDiskSize: 150
+            rootDiskType: io1
+          subregionName: eu-west-2a
+          vmType: tinav7.c4r8p1
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: capi-quickstart-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: "{{ ds.meta_data.local_hostname }}"
+          kubeletExtraArgs:
+            - name: cloud-provider
+              value: external
+            - name: provider-id
+              value: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  name: capi-quickstart-md-0
+  namespace: default
+spec:
+  clusterName: capi-quickstart
+  replicas: 3
+  rollout:
+    strategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+      type: RollingUpdate
+  selector:
+    matchLabels: {}
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiGroup: bootstrap.cluster.x-k8s.io
+          kind: KubeadmConfigTemplate
+          name: capi-quickstart-md-0
+      clusterName: capi-quickstart
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: OscMachineTemplate
+        name: capi-quickstart-md-0
+      version: v1.35.7
+```
+
+## Technical considerations
+
+Once applying the `OscCluster` manifest, pay attention to performing these actions:
+
+- The OUTSCALE Load Balancer (LBU) of the Control Plane provided by the `OscCluster` resource must be disabled, because Kamaji creates the endpoint of the Control Plane and updates `spec.controlPlaneEndpoint` based on it.
+  Without the `network.disable` option, CAPOSC would reconcile the endpoint to the LBU DNS name and fight with the Kamaji Control Plane provider over the `spec.controlPlaneEndpoint` field.
+- The `KamajiControlPlane.spec.network.serviceType: LoadBalancer` creates the Control Plane endpoint exposed by the OUTSCALE Cloud Controller Manager running in the management cluster.


### PR DESCRIPTION
The KamajiControlPlane provider now patches the [`OscCluster`](https://github.com/outscale/cluster-api-provider-outscale) `spec.controlPlaneEndpoint` with the endpoint of the TenantControlPlane, like other generic infrastructure providers. Requires CAPOSC >= v1.2.0 to disable the OUTSCALE Load Balancer via `network.disable`.
